### PR TITLE
Added protocol parameter to getStreamUrl for iOS/Quicktime support

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -84,11 +84,13 @@ class Video(PlexPartialObject):
         params['copyts'] = kwargs.get('copyts', 1)
         params['mediaIndex'] = kwargs.get('mediaIndex', 0)
         params['X-Plex-Platform'] = kwargs.get('platform', 'Chrome')
+        if 'protocol' in kwargs:
+            params['protocol'] = kwargs['protocol']
         if maxVideoBitrate:
             params['maxVideoBitrate'] = max(maxVideoBitrate, 64)
         if videoResolution and re.match('^\d+x\d+$', videoResolution):
             params['videoResolution'] = videoResolution
-        return self.server.url('/video/:/transcode/universal/start?%s' % urllib.urlencode(params))
+        return self.server.url('/video/:/transcode/universal/start.m3u8?%s' % urllib.urlencode(params))
 
     def markWatched(self):
         path = '/:/scrobble?key=%s&identifier=com.plexapp.plugins.library' % self.ratingKey


### PR DESCRIPTION
In order to support Quicktime/iOS video players the protocol parameter needs to be set to 'hls' (HTTP Live Streaming). To keep backwards compatibility intact I added it as a kwarg, though it should probably be the default.

I also added .m3u8 to the URL, though this doesn't seem to make any difference.