### PR TITLE
Update video.py: self.key already contains slash

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -119,7 +119,7 @@ class Video(PlexPartialObject):
         client.playMedia(self)
 
     def refresh(self):
-        self.server.query('/%s/refresh' % self.key, method=put)
+        self.server.query('%s/refresh' % self.key, method=put)
 
 
 class Movie(Video):


### PR DESCRIPTION
self.key already contains a leading slash therefore this call to the Plex server will fail with 404 not found.
When the slash from the query location is removed, the call will succeed.