### PR TITLE
Fix missing check for None in __eq__

### DIFF
--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -20,7 +20,7 @@ class Video(PlexPartialObject):
     TYPE = None
 
     def __eq__(self, other):
-        return self.type == other.type and self.key == other.key
+        return other is not None and self.type == other.type and self.key == other.key
 
     def __repr__(self):
         title = self.title.replace(' ','.')[0:20]


### PR DESCRIPTION
Check that the other object being compared is not None before attempting to access it.