### PR TITLE
Level for a media object might not always be an integer

### DIFF
--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -110,7 +110,10 @@ class StreamVideo(MediaPartStream):
         self.frame_rate_mode = data.attrib.get('frameRateMode')
         self.has_scalling_matrix = cast(bool, data.attrib.get('hasScallingMatrix'))
         self.height = cast(int, data.attrib.get('height'))
-        self.level = cast(int, data.attrib.get('level'))
+
+        try: self.level = cast(int, data.attrib.get('level'))
+        except ValueError: self.level = float('nan')
+
         self.profile = data.attrib.get('profile')
         self.ref_frames = cast(int, data.attrib.get('refFrames'))
         self.scan_type = data.attrib.get('scanType')


### PR DESCRIPTION
I have a problem with one episode in my library. For some reason level on the media object isn't a integer (it is a string, 'medium') so I got an exception.

I checked the web interface and they printed it as 'NaN'. So I did the same thing.

I don't know if this is the correct place to add this, maybe this should be in the cast function? So it affect all integers.