### PR TITLE
Fixing typos/errors in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ plex.library.get('Conan (2010)').markWatched()
 ```python
 # Example 3: List all clients connected to the Server.
 for client in plex.clients():
-    print(client.name)
+    print(client.title)
 ```
 ```python
 # Example 4: Play the movie Avatar on another client.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ string, you can use the PlexServer object directly as above, but passing in
 the baseurl and auth token directly.
 
 ```python
-from plexapi.server import MyPlexAccount
+from plexapi.server import PlexServer
 baseurl = 'http://plexserver:32400'
 token = '2ffLuB84dqLswk9skLos'
 plex = PlexServer(baseurl, token)


### PR DESCRIPTION
When I tried the examples as is on version 2.0.2 I got failures. 
This fixes the things I wanted to try.