### PR TITLE
Added Field tag to Video.

### DIFF
--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -186,3 +186,15 @@ class Producer(MediaTag): TYPE = 'Producer'; FILTER = 'producer'
 class Role(MediaTag): TYPE = 'Role'; FILTER = 'role'
 class Similar(MediaTag): TYPE = 'Similar'; FILTER = 'similar'
 class Writer(MediaTag): TYPE = 'Writer'; FILTER = 'writer'
+
+
+class Field(object):
+    TYPE = 'Field'
+
+    def __init__(self, data):
+        self.name = data.attrib.get('name')
+        self.locked = cast(bool, data.attrib.get('locked'))
+
+    def __repr__(self):
+        name = self.name.replace(' ', '.')[0:20]
+        return '<%s:%s:%s>' % (self.__class__.__name__, name, self.locked)

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -89,6 +89,7 @@ class Movie(Video, Playable):
             self.producers = [media.Producer(self.server, e) for e in data if e.tag == media.Producer.TYPE]
             self.roles = [media.Role(self.server, e) for e in data if e.tag == media.Role.TYPE]
             self.writers = [media.Writer(self.server, e) for e in data if e.tag == media.Writer.TYPE]
+            self.fields = [media.Field(e) for e in data if e.tag == media.Field.TYPE]
             self.videoStreams = utils.findStreams(self.media, 'videostream')
             self.audioStreams = utils.findStreams(self.media, 'audiostream')
             self.subtitleStreams = utils.findStreams(self.media, 'subtitlestream')


### PR DESCRIPTION
I need to access Field tags for Video objects, to see if some fields are locked, for a project I'm working on. So I added Field tags support :)

The reason Field doesn't have the server property as MediaTag have, is because fields are unique for that Video object, so there is no more information to fetch from the server.

Quite basic merge request, but if you want more info or examples of how a Field tag is structured just tell me and I will add it.
