### PR TITLE
Adding PlexApiException as a base exception for all other python-plexapi exceptions.

### DIFF
--- a/plexapi/exceptions.py
+++ b/plexapi/exceptions.py
@@ -4,17 +4,20 @@
 PlexAPI Exceptions
 """
 
-class BadRequest(Exception):
+class PlexApiException(Exception):
     pass
 
-class NotFound(Exception):
+class BadRequest(PlexApiException):
     pass
 
-class UnknownType(Exception):
+class NotFound(PlexApiException):
     pass
 
-class Unsupported(Exception):
+class UnknownType(PlexApiException):
     pass
 
-class Unauthorized(Exception):
+class Unsupported(PlexApiException):
+    pass
+
+class Unauthorized(PlexApiException):
     pass


### PR DESCRIPTION
I am proposing the addition of a base exception (PlexApiException) that all other python-plexapi exceptions will extend. The purpose of this base exception is for ease of developer use. No need to catch each exception individually, when all you need to know is that at least one exception was raised; and this will provide more meaningful information than catching the built-in Exception.
