### PR TITLE
Received TypeError: unorderable types: str() >= int() when attempting to call unwatched()

### DIFF
--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -232,7 +232,7 @@ def listItems(server, path, libtype=None, watched=None, bytag=False):
     for elem in server.query(path):
         if libtype and elem.attrib.get('type') != libtype: continue
         if watched is True and elem.attrib.get('viewCount', 0) == 0: continue
-        if watched is False and elem.attrib.get('viewCount', 0) >= 1: continue
+        if watched is False and int(elem.attrib.get('viewCount', 0)) >= 1: continue
         try:
             items.append(buildItem(server, elem, path, bytag))
         except UnknownType:


### PR DESCRIPTION
The Plex API seems to return a string if the viewCount is 0 for some reason.  Casting to int fixed the issue.

Full traceback:
`Traceback (most recent call last):
  File "plex.py", line 42, in <module>
    unwatchedList = tv.get(show.title).unwatched()
  File "/usr/local/lib/python3.5/dist-packages/plexapi/video.py", line 158, in unwatched
    return self.episodes(watched=False)
  File "/usr/local/lib/python3.5/dist-packages/plexapi/video.py", line 148, in episodes
    return utils.listItems(self.server, leavesKey, watched=watched)
  File "/usr/local/lib/python3.5/dist-packages/plexapi/utils.py", line 235, in listItems
    if watched is False and elem.attrib.get('viewCount', 0) >= 1: continue
TypeError: unorderable types: str() >= int()`  

Note: I'm a beginner to GIT workflow(& Python for that matter..) I am not sure on the proper procedure for merging this 'fix' into your repo.. I forked it, cloned it, made my change, pushed it, and now I am starting the Pull Request.  Is that right?