### PR TITLE
cast viewCount to int

### DIFF
--- a/plexapi/utils.py
+++ b/plexapi/utils.py
@@ -460,9 +460,9 @@ def listItems(server, path, libtype=None, watched=None, bytag=False):
     for elem in server.query(path):
         if libtype and elem.attrib.get('type') != libtype:
             continue
-        if watched is True and elem.attrib.get('viewCount', 0) == 0:
+        if watched is True and int(elem.attrib.get('viewCount', 0)) == 0:
             continue
-        if watched is False and elem.attrib.get('viewCount', 0) >= 1:
+        if watched is False and int(elem.attrib.get('viewCount', 0)) >= 1:
             continue
         try:
             items.append(buildItem(server, elem, path, bytag))


### PR DESCRIPTION
I ran into this:

```
  File "/pyenv/lib/python3.5/site-packages/plexapi/video.py", line 158, in unwatched
    return self.episodes(watched=False)
  File "/pyenv/lib/python3.5/site-packages/plexapi/video.py", line 148, in episodes
    return utils.listItems(self.server, leavesKey, watched=watched)
  File "/pyenv/lib/python3.5/site-packages/plexapi/utils.py", line 235, in listItems
    if watched is False and elem.attrib.get('viewCount', 0) >= 1: continue
TypeError: unorderable types: str() >= int()
```

Simply casting to an int should fix.