### PR TITLE
i think i got a list with [None]

### DIFF
--- a/plexapi/myplex.py
+++ b/plexapi/myplex.py
@@ -329,7 +329,7 @@ class MyPlexResource(object):
                 'Testing resource connection: %s?X-Plex-Token=%s %s', url, token, okerr)
 
         results = [r[2] for r in results if r and r is not None]
-        if not results:
+        if not any(results):
             raise NotFound('Unable to connect to resource: %s' % self.name)
         log.info('Connecting to server: %s?X-Plex-Token=%s',
                  results[0].baseurl, results[0].token)


### PR DESCRIPTION
While trying to connect to a friend's server that is currently offline, I got this exception

```
Traceback (most recent call last):

...

  File "/code/playlists/models.py", line 106, in import_servers
    conn = plex_server_resource.connect()
  File "/pyenv/src/plexapi/plexapi/myplex.py", line 335, in connect
    results[0].baseurl, results[0].token)
AttributeError: 'NoneType' object has no attribute 'baseurl'
```

I believe this happened because `r[2]` somehow ended up as None and so the filtering wasn't enough